### PR TITLE
I've attempted to hide the Hume logo using CSS.

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -57,3 +57,9 @@
     @apply bg-background text-foreground;
   }
 }
+
+.hume-logo,
+.hume-brand,
+.hume-watermark {
+  display: none !important;
+}


### PR DESCRIPTION
I added some CSS rules to `app/globals.css` to hide elements with class names often used for branding, like `.hume-logo`, `.hume-brand`, or `.hume-watermark`.

This is an effort to resolve the issue of the Hume logo appearing in the top corner of your page.