### PR TITLE
Fix TypeScript error in Chat.tsx

### DIFF
--- a/utils/salesScripts.ts
+++ b/utils/salesScripts.ts
@@ -1,9 +1,9 @@
-interface ScriptStep {
+export interface ScriptStep {
   prompt: string;
   userResponseOptions: string[];
 }
 
-type SalesScript = ScriptStep[];
+export type SalesScript = ScriptStep[];
 
 const salesScripts: SalesScript[] = [
   // Script 1: Initial Greeting and Qualification


### PR DESCRIPTION
I updated utils/salesScripts.ts to export SalesScript and ScriptStep as named exports. This resolves the TypeScript error in components/Chat.tsx where these types were not being imported correctly.